### PR TITLE
Modernization

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -132,13 +132,13 @@ class syntax_plugin_onlinenumber extends DokuWiki_Syntax_Plugin {
     }
 
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         return explode('|', substr($match, strlen('{{onlinenumber|'), -2));
 
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         define('PLUGIN_ONLINE_TIMEOUT', $this->getConf('onlineseconds')); // Count users in N seconds
         
         // List of 'IP-address|last-access-time(seconds)'


### PR DESCRIPTION
_[Tue Nov 19 07:35:35.176578 2019] [php7:warn] [pid 17218] [client <...> :28752] PHP Warning:  Declaration of syntax_plugin_onlinenumber::render($mode, &$renderer, $data) should be compatible with DokuWiki_Syntax_Plugin::render($format, Doku_Renderer $renderer, $data) in /var/www/<...>/lib/plugins/onlinenumber/syntax.php on line 188_

From now server logs become clear.